### PR TITLE
Add testimonial carousel

### DIFF
--- a/app/components/TestimonialCarousel.tsx
+++ b/app/components/TestimonialCarousel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+const testimonials = [
+  {
+    quote:
+      "Chef Alex delivered a flawless five-course meal that our guests still rave about.",
+    author: "Olivia P., Corporate Event",
+  },
+  {
+    quote:
+      "The flavours were unbelievable and the service was top-notch. Truly memorable!",
+    author: "Marcus T., Wedding Reception",
+  },
+  {
+    quote:
+      "Our festival attendees couldn’t get enough of the creative dishes Alex served.",
+    author: "Sasha L., Summer Festival",
+  },
+];
+
+export default function TestimonialCarousel() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % testimonials.length);
+    }, 7000);
+    return () => clearInterval(id);
+  }, []);
+
+  const t = testimonials[index];
+
+  return (
+    <div className="relative mx-auto max-w-xl flex items-center justify-center h-60">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, x: 50 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -50 }}
+          transition={{ duration: 0.5 }}
+          className="relative bg-primary2 p-8 text-accent2 w-full"
+        >
+          <p className="text-xl leading-relaxed mb-4">“{t.quote}”</p>
+          <footer className="text-sm opacity-70">— {t.author}</footer>
+          <svg
+            className="absolute inset-0 w-full h-full pointer-events-none"
+            viewBox="0 0 400 200"
+            preserveAspectRatio="none"
+          >
+            <path
+              d="M0,20 Q20,0 40,20 T80,20 T120,20 T160,20 T200,20 T240,20 T280,20 T320,20 T360,20 Q380,0 400,20 L400,180 Q380,200 360,180 T320,180 T280,180 T240,180 T200,180 T160,180 T120,180 T80,180 T40,180 Q20,200 0,180Z"
+              fill="none"
+              stroke="var(--color-stroke)"
+              strokeWidth="6"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import ColorManager from './components/ColorManager'
 import QuoteChat from './components/QuoteChat'
 import { motion, useScroll, useTransform } from 'framer-motion'
 import { useState, useEffect } from 'react'
-import TextMarquee from './components/TextMarquee';
+import TestimonialCarousel from './components/TestimonialCarousel';
 
 
 
@@ -326,15 +326,7 @@ function HomeContent() {
 
       {/* testimonials */}
       <section id="testimonials" className="relative bg-primary2 text-center py-24 px-4">
-        <img
-          src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1600&q=60"
-          className="absolute inset-0 w-full h-full object-cover opacity-0"
-          alt="Food background"
-        />
-        <blockquote className="relative z-10 max-w-3xl mx-auto text-2xl sm:text-3xl font-light leading-relaxed">
-          &quot;Chef Alex delivered a flawless five-course meal that our guests still rave about.&quot;
-          <footer className="mt-6 text-sm opacity-70">— Olivia P., Corporate Event</footer>
-        </blockquote>
+        <TestimonialCarousel />
       </section>
 
       <svg


### PR DESCRIPTION
## Summary
- add new `TestimonialCarousel` component with a playful wavy border
- embed new carousel into Testimonials section of the home page

## Testing
- `npm run build` *(fails: GROQ_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b7b895ef48323b5bd88f43e1980a4