### PR TITLE
Load homepage content via admin API

### DIFF
--- a/app/components/EventHighlights.tsx
+++ b/app/components/EventHighlights.tsx
@@ -8,7 +8,7 @@ type Event = {
   description: string
 }
 
-const events: Event[] = [
+const defaultEvents: Event[] = [
   {
     id: 1,
     image: '/images/events/dinnerparty (1).jpg',
@@ -77,7 +77,7 @@ const shapes = [
   'M48.3,-68.1C61.8,-66.6,71.2,-51.7,72.1,-36.7C73.1,-21.7,65.6,-6.7,63.8,9.5C62,25.7,65.9,43.1,59.4,52.4C52.8,61.7,35.8,62.9,19.7,67.9C3.7,72.8,-11.4,81.7,-25.1,80.1C-38.8,78.6,-51.1,66.7,-56.5,53.1C-62,39.4,-60.7,24,-63.4,8.8C-66.1,-6.4,-72.8,-21.4,-69.4,-32.8C-65.9,-44.2,-52.2,-52,-38.9,-53.6C-25.7,-55.1,-12.8,-50.3,2.3,-53.9C17.5,-57.5,34.9,-69.5,48.3,-68.1Z'
 ]
 
-export default function EventHighlights() {
+export default function EventHighlights({ events = defaultEvents }: { events?: Event[] }) {
   const [index, setIndex] = useState(0)
   const pathRef = useRef<SVGPathElement>(null)
   const count = events.length

--- a/app/components/MobilePlateCarousel.tsx
+++ b/app/components/MobilePlateCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from 'react'
 
-export default function MobilePlateCarousel() {
+export default function MobilePlateCarousel({ items }: { items: string[] }) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const touchStartX = useRef(0)
   const touchEndX = useRef(0)
@@ -28,44 +28,7 @@ export default function MobilePlateCarousel() {
   // Combine first plate with text plates
   const allPlates = [firstPlate, ...textPlatePaths]
 
-  // Menu items for text plates
-  const items = [
-    'Stuffed Calamari: N\'Duja Parsley Oil, Herbs',
-    'Seared Cabbage: Almond Chili Butter & Chives',
-    'Crostini: Mushroom, Truffle, Gorgonzola, Mascarpone, Caramelized Onion, Thyme',
-    'Scallop: Aji Blanco, Dill, Almonds, Cucumber',
-    'Summer Salad: Ontario Peas, Charred Broccolini, Red Onion, Cumin, Yogurt, Fennel, Mint, Lemon',
-    'Burrata: Roasted Grapes, Pistachio, Saba, Basil',
-    'Oysters: Caesar · Black Garlic/Fermented Chili · Mignonette · Lime/Ginger/Fish Sauce Granita',
-    'Tomato Carpaccio: N\'Duja Vinaigrette, Stracciatella Di Bufala, EVOO',
-    'Braised Beef: Birria Demi, Onion Cracker, Pickled Radish, Cilantro Oil, Spiced Carrot',
-    'Roasted Chicken: Guyanese Curry Reduction, Potato',
-    'Pan-Seared Perch: Prosecco Beurre Blanc, Pickled Chilis, Herbs',
-    'Veal Tenderloin: Rapini Pesto, Pan Jus, Pear Caponata',
-    'Fennel & Cherry Tomato Gratin: Green Olive, Celery & Raisin Salsa',
-    'Cardamom Panna Cotta: Quince Gelée, Toasted Milk Crumb',
-    'Citrus Olive Oil Cake: Mascarpone, Basil Sorbet',
-    'Hot Chocolate Tiramisu',
-    'Berry & Stone Fruit: Almond Crumble, Whipped Vanilla Ganache',
-    'Corn Cake: Popcorn Gelato, Corn Pops',
-    'Spiced Chocolate Cake: Marshmallow, Buttered Graham Cracker Gelato, Spiced Chocolate Crème',
-    'Parmesan & Thyme Muffins',
-    'Guinness‐Braised Beef Stew with Mini Yorkshire Puddings',
-    'Rabbit Orecchiette',
-    'Potenza‐Style Chicken: Fresh Tomato, Basil',
-    'Pollo Mattone with Pan Jus',
-    'Savoury Bread Pudding',
-    'Zesty Kale Salad & Date Dressing',
-    'Baby Gem Lettuce: Burnt Lemon Dressing, Pecorino',
-    'XO Grilled Shrimp',
-    'Cannoli Tartare',
-    'Japchae',
-    'Braised Chicken Phyllo Cups',
-    'Dauphine Potato: Black Garlic, Tomato, Beef',
-    'Empanadas',
-    'Goat Cheese & Tomato Tartlet',
-    'Seasonal Tasting Menu: 5-course seasonal menu subject to change depending on season & availability',
-  ]
+  // Menu items provided via props
 
   // Distribute menu items evenly across text plates
   function distributeItemsEvenly() {

--- a/app/components/PlateStack.tsx
+++ b/app/components/PlateStack.tsx
@@ -7,7 +7,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger'
 // Register ScrollTrigger plugin
 gsap.registerPlugin(ScrollTrigger)
 
-export default function PlateStack() {
+export default function PlateStack({ items }: { items: string[] }) {
   const stackRef = useRef<HTMLDivElement>(null)
   const [shuffledPlates, setShuffledPlates] = useState<string[]>([])
 
@@ -55,51 +55,14 @@ export default function PlateStack() {
   const defaultPlates = [...noTextPathsOriginal, ...textPlatePaths]
   const allPlates = shuffledPlates.length > 0 ? shuffledPlates : defaultPlates
 
-  // ── flat list of every single menu item ────────────────────────────────
-  const items = [
-    'Stuffed Calamari: N\'Duja Parsley Oil, Herbs',
-    'Seared Cabbage: Almond Chili Butter & Chives',
-    'Crostini: Mushroom, Truffle, Gorgonzola, Mascarpone, Caramelized Onion, Thyme',
-    'Scallop: Aji Blanco, Dill, Almonds, Cucumber',
-    'Summer Salad: Ontario Peas, Charred Broccolini, Red Onion, Cumin, Yogurt, Fennel, Mint, Lemon',
-    'Burrata: Roasted Grapes, Pistachio, Saba, Basil',
-    'Oysters: Caesar · Black Garlic/Fermented Chili · Mignonette · Lime/Ginger/Fish Sauce Granita',
-    'Tomato Carpaccio: N\'Duja Vinaigrette, Stracciatella Di Bufala, EVOO',
-    'Braised Beef: Birria Demi, Onion Cracker, Pickled Radish, Cilantro Oil, Spiced Carrot',
-    'Roasted Chicken: Guyanese Curry Reduction, Potato',
-    'Pan-Seared Perch: Prosecco Beurre Blanc, Pickled Chilis, Herbs',
-    'Veal Tenderloin: Rapini Pesto, Pan Jus, Pear Caponata',
-    'Fennel & Cherry Tomato Gratin: Green Olive, Celery & Raisin Salsa',
-    'Cardamom Panna Cotta: Quince Gelée, Toasted Milk Crumb',
-    'Citrus Olive Oil Cake: Mascarpone, Basil Sorbet',
-    'Hot Chocolate Tiramisu',
-    'Berry & Stone Fruit: Almond Crumble, Whipped Vanilla Ganache',
-    'Corn Cake: Popcorn Gelato, Corn Pops',
-    'Spiced Chocolate Cake: Marshmallow, Buttered Graham Cracker Gelato, Spiced Chocolate Crème',
-    'Parmesan & Thyme Muffins',
-    'Guinness‐Braised Beef Stew with Mini Yorkshire Puddings',
-    'Rabbit Orecchiette',
-    'Potenza‐Style Chicken: Fresh Tomato, Basil',
-    'Pollo Mattone with Pan Jus',
-    'Savoury Bread Pudding',
-    'Zesty Kale Salad & Date Dressing',
-    'Baby Gem Lettuce: Burnt Lemon Dressing, Pecorino',
-    'XO Grilled Shrimp',
-    'Cannoli Tartare',
-    'Japchae',
-    'Braised Chicken Phyllo Cups',
-    'Dauphine Potato: Black Garlic, Tomato, Beef',
-    'Empanadas',
-    'Goat Cheese & Tomato Tartlet',
-    'Seasonal Tasting Menu: 5-course seasonal menu subject to change depending on season & availability',
-  ]
+  // Items provided via props
 
   // ── build 12 badges, distributing text evenly by length ────────────────
   function distributeItemsEvenly() {
     const plateCount = textPlatePaths.length
     const plateGroups: string[][] = Array.from({ length: plateCount }, () => [])
     const plateLengths: number[] = Array(plateCount).fill(0)
-    
+
     // Sort items by length (longest first) for better distribution
     const sortedItems = [...items].sort((a, b) => b.length - a.length)
     

--- a/app/components/admin/defaultData.ts
+++ b/app/components/admin/defaultData.ts
@@ -1,0 +1,130 @@
+export const defaultMenuItems = [
+  'Stuffed Calamari: N\'Duja Parsley Oil, Herbs',
+  'Seared Cabbage: Almond Chili Butter & Chives',
+  'Crostini: Mushroom, Truffle, Gorgonzola, Mascarpone, Caramelized Onion, Thyme',
+  'Scallop: Aji Blanco, Dill, Almonds, Cucumber',
+  'Summer Salad: Ontario Peas, Charred Broccolini, Red Onion, Cumin, Yogurt, Fennel, Mint, Lemon',
+  'Burrata: Roasted Grapes, Pistachio, Saba, Basil',
+  'Oysters: Caesar · Black Garlic/Fermented Chili · Mignonette · Lime/Ginger/Fish Sauce Granita',
+  'Tomato Carpaccio: N\'Duja Vinaigrette, Stracciatella Di Bufala, EVOO',
+  'Braised Beef: Birria Demi, Onion Cracker, Pickled Radish, Cilantro Oil, Spiced Carrot',
+  'Roasted Chicken: Guyanese Curry Reduction, Potato',
+  'Pan-Seared Perch: Prosecco Beurre Blanc, Pickled Chilis, Herbs',
+  'Veal Tenderloin: Rapini Pesto, Pan Jus, Pear Caponata',
+  'Fennel & Cherry Tomato Gratin: Green Olive, Celery & Raisin Salsa',
+  'Cardamom Panna Cotta: Quince Gelée, Toasted Milk Crumb',
+  'Citrus Olive Oil Cake: Mascarpone, Basil Sorbet',
+  'Hot Chocolate Tiramisu',
+  'Berry & Stone Fruit: Almond Crumble, Whipped Vanilla Ganache',
+  'Corn Cake: Popcorn Gelato, Corn Pops',
+  'Spiced Chocolate Cake: Marshmallow, Buttered Graham Cracker Gelato, Spiced Chocolate Crème',
+  'Parmesan & Thyme Muffins',
+  'Guinness‐Braised Beef Stew with Mini Yorkshire Puddings',
+  'Rabbit Orecchiette',
+  'Potenza‐Style Chicken: Fresh Tomato, Basil',
+  'Pollo Mattone with Pan Jus',
+  'Savoury Bread Pudding',
+  'Zesty Kale Salad & Date Dressing',
+  'Baby Gem Lettuce: Burnt Lemon Dressing, Pecorino',
+  'XO Grilled Shrimp',
+  'Cannoli Tartare',
+  'Japchae',
+  'Braised Chicken Phyllo Cups',
+  'Dauphine Potato: Black Garlic, Tomato, Beef',
+  'Empanadas',
+  'Goat Cheese & Tomato Tartlet',
+  'Seasonal Tasting Menu: 5-course seasonal menu subject to change depending on season & availability',
+];
+
+export const defaultTestimonials = [
+  'Chef Alex transformed our backyard into a Michelin-starred experience. Every dish was a masterpiece!',
+  'The attention to detail was incredible. From the menu planning to the final presentation, everything was perfect.',
+  "Our corporate event was a huge success thanks to Chef Alex's innovative menu and professional service.",
+  'The seasonal tasting menu was a journey through local flavors. Each course told a story.',
+  'What impressed me most was how Chef Alex made everyone feel like family while maintaining professional excellence.',
+  'The family-style feast was perfect for our large gathering. Everyone raved about the food!',
+  "Chef Alex's passion for local ingredients shines through in every dish. Truly exceptional dining.",
+  'The wine pairings were spot on, and the service was impeccable. A memorable evening!',
+  'From intimate dinners to large events, Chef Alex delivers consistently outstanding experiences.',
+];
+
+export const defaultGalleryEvents = [
+  {
+    id: 1,
+    image: '/images/events/dinnerparty (1).jpg',
+    alt: 'Dinner in a contemporary art gallery',
+    description:
+      'A quiet, thoughtful evening where every plate felt like part of the exhibit. The space was clean and bright, the food minimal but intentional. Each course landed with a sense of purpose—no showboating, no filler. Just great pacing, warm lighting, and a menu built to reflect the art on the walls.',
+  },
+  {
+    id: 2,
+    image: '/images/events/dinnerparty (4).jpg',
+    alt: 'Loft dinner filled with candles, plants, and soft light',
+    description:
+      'This felt like spring indoors—fresh herbs on the table, linen napkins just barely wrinkled, and dishes that tasted like someone cared. Served family-style, the menu moved from light and bright to deeply comforting. Everything smelled like lemon zest, olive oil, and trust.',
+  },
+  {
+    id: 3,
+    image: '/images/events/dinnerparty (5).jpg',
+    alt: 'Late-night dinner thrown in a brick-and-beam loft downtown',
+    description:
+      'Held in a raw industrial space with long tables and loose rules, this dinner ditched formalities in favour of good wine and better pacing. Dishes came out slow and generous—built to anchor conversation, not interrupt it. A full-bodied, brick-walled kind of night that hit its stride after the second bottle.',
+  },
+  {
+    id: 4,
+    image: '/images/events/dinnerparty (7).jpg',
+    alt: 'A private dinner hosted aboard a wood-paneled boat',
+    description:
+      'Waves tapping at the hull, glasses clinking on wood—this was one of those "how is this real?" dinners. The courses felt coastal and precise, plated between portside views and clean ocean air. It moved like a tide: calm, then surprising. You left feeling lighter.',
+  },
+  {
+    id: 5,
+    image: '/images/events/dinnerparty (8).jpg',
+    alt: 'Dinner in a winery hall overlooking rows of vines',
+    description:
+      'Set against a backdrop of late-summer vineyards, this dinner leaned into the earthy and elemental. Stoneware plates, wood-fired mains, and wine poured with zero ceremony. The kind of evening that starts golden and ends with sweaters over shoulders and forks chasing the last bite of something warm.',
+  },
+  {
+    id: 6,
+    image: '/images/events/dinnerparty (9).jpg',
+    alt: 'Rooftop dinner framed by city skylines and patio plants',
+    description:
+      'Equal parts dinner and hang, this rooftop gathering delivered that perfect balance of casual and magic. Music low, wine cold, and food that arrived when it was ready. Nothing rushed, everything easy. If you\'ve ever wanted a dinner to feel like a soft landing, this was it.',
+  },
+  {
+    id: 7,
+    image: '/images/events/dinnerparty (10).jpg',
+    alt: 'Minimalist dinner inside a concrete-walled private room',
+    description:
+      'This one played with restraint. The setting was clean and architectural, the menu stripped of anything unnecessary. No centerpieces, no noise—just elegant plates arriving in rhythm and disappearing just as quietly. Precision without pretense.',
+  },
+  {
+    id: 8,
+    image: '/images/events/dinnerparty (11).jpg',
+    alt: 'Tightly lit dinner in a tucked-away private space',
+    description:
+      'Tucked behind a nondescript door and down a quiet hallway, this dinner had that rare "you had to be there" feel. The food was vibrant and unexpected, the mood a little rowdy, but always intentional. Designed to feel like a secret—one you\'re glad got out.',
+  },
+];
+
+export const defaultCopy = [
+  { section: 'hero_title', content: 'restaurant-quality<br />private dining' },
+  {
+    section: 'hero_subtitle',
+    content:
+      'From intimate dinners to large galas, Chef Alex J crafts unforgettable culinary experiences wherever you celebrate.',
+  },
+  { section: 'about_heading', content: 'Meet Chef Alex J' },
+  {
+    section: 'about_p1',
+    content:
+      'Raised in bustling family kitchens in Montréal and Toronto, Alex learned early on that the best way to care for people is through food. Eighteen years later, that passion still drives him. From intimate dinners to large festivals, he brings the flavours and techniques he grew up loving to every plate he serves.',
+  },
+  {
+    section: 'about_p2',
+    content:
+      "Every event is tailored to your unique tastes and needs—because when you dine with us, you're family.",
+  },
+  { section: 'about_p3', content: 'Welcome to the family,<br />Alex' },
+  { section: 'booking_heading', content: "Let's Craft Your Event" },
+];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,10 @@ function HomeContent() {
   const [parallaxOffset, setParallaxOffset] = useState({ x: 0, y: 0, tiltX: 0, tiltY: 0 });
   const [bookingBgImage, setBookingBgImage] = useState('');
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [copy, setCopy] = useState<Record<string, string>>({});
+  const [menuItems, setMenuItems] = useState<string[]>([]);
+  const [testimonials, setTestimonials] = useState<string[]>([]);
+  const [galleryEvents, setGalleryEvents] = useState<any[]>([]);
   const { scrollY } = useScroll();
   
   // Refs for hero text animation
@@ -74,6 +78,39 @@ function HomeContent() {
     loadFont('Anton');
     loadFont('Bitter');
     loadFont('Oswald');
+
+    // Fetch dynamic data
+    const fetchData = async () => {
+      const copyRes = await fetch('/api/admin/content');
+      if (copyRes.ok) {
+        const data = await copyRes.json();
+        const map: Record<string, string> = {};
+        data.forEach((item: any) => {
+          map[item.section] = item.content;
+        });
+        setCopy(map);
+      }
+
+      const menuRes = await fetch('/api/admin/menu');
+      if (menuRes.ok) {
+        const m = await menuRes.json();
+        setMenuItems(m.map((i: any) => i.name));
+      }
+
+      const tRes = await fetch('/api/admin/testimonials');
+      if (tRes.ok) {
+        const t = await tRes.json();
+        setTestimonials(t.map((x: any) => x.quote || x.content));
+      }
+
+      const gRes = await fetch('/api/admin/gallery');
+      if (gRes.ok) {
+        const g = await gRes.json();
+        setGalleryEvents(g);
+      }
+    };
+
+    fetchData();
 
     // Set random background image for booking section
     const backgroundImages = [
@@ -427,19 +464,16 @@ function HomeContent() {
 
 
   <div className="relative z-10 text-center px-4">
-    <h1 
+    <h1
       ref={heroTitleRef}
       className="font-display tracking-tight text-3xl sm:text-5xl md:text-7xl leading-snug sm:leading-tight uppercase drop-shadow-lg"
-    >
-      restaurant-quality<br />private dining
-    </h1>
-    <p 
+      dangerouslySetInnerHTML={{ __html: copy['hero_title'] || '' }}
+    />
+    <p
       ref={heroSubtitleRef}
       className="mt-6 max-w-xl mx-auto text-lg drop-shadow-lg"
-    >
-      From intimate dinners to large galas, Chef Alex J crafts unforgettable culinary experiences wherever you
-      celebrate.
-    </p>
+      dangerouslySetInnerHTML={{ __html: copy['hero_subtitle'] || '' }}
+    />
     
       <a
       href="#booking"
@@ -501,28 +535,25 @@ function HomeContent() {
 
 
 <div ref={textRef}>
-<h2 className="font-display text-accent2 text-4xl sm:text-5xl mb-4">
-    Meet Chef Alex J
-  </h2>
+<h2
+    className="font-display text-accent2 text-4xl sm:text-5xl mb-4"
+    dangerouslySetInnerHTML={{ __html: copy['about_heading'] || '' }}
+  />
 
-  <p className="text-accent2 mb-4">
-    Raised in bustling family kitchens in Montréal and Toronto, Alex learned
-    early on that the best way to care for people is through food. Eighteen
-    years later, that passion still drives him. From intimate dinners to large
-    festivals, he brings the flavours and techniques he grew up loving to every
-    plate he serves.
-  </p>
+  <p
+    className="text-accent2 mb-4"
+    dangerouslySetInnerHTML={{ __html: copy['about_p1'] || '' }}
+  />
 
-  <p className="text-accent2 mb-4">
-    Every event is tailored to your unique tastes and needs—because when you
-    dine with us, you're family.
-  </p>
+  <p
+    className="text-accent2 mb-4"
+    dangerouslySetInnerHTML={{ __html: copy['about_p2'] || '' }}
+  />
 
-  <p className="text-accent2 mb-4">
-    Welcome to the family,
-    <br />
-    Alex
-  </p>
+  <p
+    className="text-accent2 mb-4"
+    dangerouslySetInnerHTML={{ __html: copy['about_p3'] || '' }}
+  />
     </div>
   </div>
 </section>
@@ -554,7 +585,7 @@ d="M0,224L34.3,240C68.6,256,137,288,206,282.7C274.3,277,343,235,
       Event Highlights
     </TextMarquee>
   </div>
-  <EventHighlights />
+  <EventHighlights events={galleryEvents} />
 </section>
 
 
@@ -598,11 +629,11 @@ d="M0,224L34.3,240C68.6,256,137,288,206,282.7C274.3,277,343,235,
       <div className="px-4 sm:px-8 h-full flex items-center justify-center relative z-50">
         {/* Mobile carousel */}
         <div className="block sm:hidden w-full">
-          <MobilePlateCarousel />
+          <MobilePlateCarousel items={menuItems} />
         </div>
         {/* Desktop plate stack */}
         <div className="hidden sm:block w-full">
-          <PlateStack />
+          <PlateStack items={menuItems} />
         </div>
       </div>
     </div>
@@ -637,19 +668,9 @@ d="M0,224L34.3,240C68.6,256,137,288,206,282.7C274.3,277,343,235,
           </TextMarquee>
         </div>
         <div className="px-4">
-          <VerticalMarquee 
-            items={[
-              "Chef Alex transformed our backyard into a Michelin-starred experience. Every dish was a masterpiece!",
-              "The attention to detail was incredible. From the menu planning to the final presentation, everything was perfect.",
-              "Our corporate event was a huge success thanks to Chef Alex's innovative menu and professional service.",
-              "The seasonal tasting menu was a journey through local flavors. Each course told a story.",
-              "What impressed me most was how Chef Alex made everyone feel like family while maintaining professional excellence.",
-              "The family-style feast was perfect for our large gathering. Everyone raved about the food!",
-              "Chef Alex's passion for local ingredients shines through in every dish. Truly exceptional dining.",
-              "The wine pairings were spot on, and the service was impeccable. A memorable evening!",
-              "From intimate dinners to large events, Chef Alex delivers consistently outstanding experiences."
-            ]}
-            speed={30} // Slightly slower speed for better readability
+          <VerticalMarquee
+            items={testimonials}
+            speed={30}
             className="max-w-6xl mx-auto"
           />
         </div>
@@ -676,7 +697,7 @@ d="M0,224L34.3,240C68.6,256,137,288,206,282.7C274.3,277,343,235,
   <div className="relative z-10">
     <div className="w-full max-w-none">
       <TextMarquee className="text-center font-display text-3xl sm:text-5xl uppercase mb-12 text-accent2 drop-shadow-lg">
-        Let&apos;s Craft Your Event
+        {copy['booking_heading'] || ''}
       </TextMarquee>
     </div>
     <div className="px-4 sm:px-6 lg:px-8 max-w-xl mx-auto">


### PR DESCRIPTION
## Summary
- add defaultData constants for admin section
- make EventHighlights, PlateStack and MobilePlateCarousel accept props
- fetch copy, menu, gallery and testimonial data in Home page
- display fetched data instead of hardcoded text

## Testing
- `pnpm lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6855cc0b121c832392b4625072da6966