### PR TITLE
Fix mobile scroll issue

### DIFF
--- a/app/components/QuoteChat.tsx
+++ b/app/components/QuoteChat.tsx
@@ -50,13 +50,17 @@ const QuoteChat: React.FC = () => {
 
   useEffect(() => {
     if (inputRef.current && !isLoading && !showBookingForm) {
-      try {
-        inputRef.current.focus({ preventScroll: true });
-      } catch {
-        inputRef.current.focus();        // fallback for browsers that don't support preventScroll
+      const isDesktop =
+        typeof window !== 'undefined' && window.innerWidth >= 1024
+      if (isDesktop) {
+        try {
+          inputRef.current.focus({ preventScroll: true })
+        } catch {
+          inputRef.current.focus() // fallback for browsers that don't support preventScroll
+        }
       }
     }
-  }, [isLoading, showBookingForm]);
+  }, [isLoading, showBookingForm])
 
   /* initial greeting */
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent QuoteChat from auto-focusing on small screens

## Testing
- `pnpm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_685b6d2696f48323b484a7c59f0895d8