### PR TITLE
Fix caching and theme loading

### DIFF
--- a/app/api/public/content/route.ts
+++ b/app/api/public/content/route.ts
@@ -5,6 +5,8 @@ import { Query } from 'firebase-admin/firestore';
 // Force dynamic rendering since this API uses query parameters
 export const dynamic = 'force-dynamic';
 
+export const revalidate = 0
+
 export async function GET(request: NextRequest) {
   try {
     console.log('📖 Public Content API: Fetching public content...');
@@ -50,22 +52,34 @@ export async function GET(request: NextRequest) {
 
     console.log(`📖 Retrieved ${data.length} documents from ${collection}`);
     
-    return NextResponse.json({
-      success: true,
-      data,
-      collection,
-      count: data.length
-    });
+    return NextResponse.json(
+      {
+        success: true,
+        data,
+        collection,
+        count: data.length
+      },
+      {
+        headers: {
+          'Cache-Control': 'no-store, must-revalidate'
+        }
+      }
+    );
 
   } catch (error) {
     console.error('📖 Public Content API Error:', error);
     
     return NextResponse.json(
-      { 
+      {
         error: 'Failed to fetch content',
         message: error instanceof Error ? error.message : 'Unknown error'
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          'Cache-Control': 'no-store, must-revalidate'
+        }
+      }
     );
   }
 } 

--- a/app/api/public/events/route.ts
+++ b/app/api/public/events/route.ts
@@ -20,9 +20,9 @@ async function handleGet() {
   
   return new Response(JSON.stringify(events), {
     status: 200,
-    headers: { 
+    headers: {
       'Content-Type': 'application/json',
-      'Cache-Control': 'no-cache'
+      'Cache-Control': 'no-store, must-revalidate'
     },
   });
 }

--- a/app/components/EventHighlights.tsx
+++ b/app/components/EventHighlights.tsx
@@ -61,7 +61,7 @@ export default function EventHighlights() {
 
   return (
     <div className="w-full min-h-[800px] flex items-center justify-center relative overflow-hidden -translate-y-[100px]">
-      <div className="relative z-10 w-full max-w-7xl mx-auto px-16 flex items-center justify-between h-full translate-y-28">
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-4 sm:px-16 flex items-center justify-between h-full translate-y-28">
         <button
           onClick={prev}
           aria-label="Previous"
@@ -70,7 +70,7 @@ export default function EventHighlights() {
           <ChevronLeft className="w-4 h-4 text-white" />
         </button>
 
-        <div className="flex-1 mx-12 flex items-center justify-center gap-16">
+        <div className="flex-1 mx-0 sm:mx-12 flex items-center justify-center gap-8 sm:gap-16">
           <div className="flex-1 max-w-lg">
             <h2 className="text-3xl font-bold uppercase mb-4 text-accent2">
               {events[index]?.title || 'Loading...'}
@@ -84,7 +84,7 @@ export default function EventHighlights() {
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="-100 -100 200 200"
-    className="w-full max-w-[800px] h-[800px] pointer-events-none"
+    className="w-full max-w-[350px] h-[350px] sm:max-w-[800px] sm:h-[800px] pointer-events-none"
     clipPathUnits="userSpaceOnUse"
   >
               <defs>

--- a/app/components/QuoteChat.tsx
+++ b/app/components/QuoteChat.tsx
@@ -50,13 +50,17 @@ const QuoteChat: React.FC = () => {
 
   useEffect(() => {
     if (inputRef.current && !isLoading && !showBookingForm) {
-      try {
-        inputRef.current.focus({ preventScroll: true });
-      } catch {
-        inputRef.current.focus();        // fallback for browsers that don't support preventScroll
+      const isDesktop =
+        typeof window !== 'undefined' && window.innerWidth >= 1024
+      if (isDesktop) {
+        try {
+          inputRef.current.focus({ preventScroll: true })
+        } catch {
+          inputRef.current.focus() // fallback for browsers that don't support preventScroll
+        }
       }
     }
-  }, [isLoading, showBookingForm]);
+  }, [isLoading, showBookingForm])
 
   /* initial greeting */
   useEffect(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import dynamic from 'next/dynamic'
 import { Dialog } from '@headlessui/react'
 import useApi from '@/lib/useApi'
+import useTheme from '@/lib/useTheme'
 const BounceArrow = dynamic(() => import('./components/BounceArrow'), { ssr: false })
 
 type ContentItem = {
@@ -35,6 +36,7 @@ function HomeContent() {
   const [copied, setCopied] = useState(false);
   const { scrollY } = useScroll();
   const contentData = useApi<ContentItem>('content');
+  const theme = useTheme();
   
   // Helper function to get content by section
   const getContent = (section: string, fallback: string = '') => {
@@ -61,23 +63,9 @@ function HomeContent() {
   };
 
   useEffect(() => {
-    // Lock in current colors and fonts
+    if (!theme) return;
     const root = document.documentElement;
-    
-    // Set locked colors (current values with -72% brightness on primaries)
-    root.style.setProperty('--color-primary1', '#1c1b20');
-    root.style.setProperty('--color-primary2', '#383234');
-    root.style.setProperty('--color-primary3', '#3f393c');
-    root.style.setProperty('--color-accent1', '#e3973b');
-    root.style.setProperty('--color-accent2', '#ee962b');
-    root.style.setProperty('--color-stroke', '#532030');
-    
-    // Set locked fonts (current values from your font picker)
-    root.style.setProperty('--font-display', '"Anton", cursive');
-    root.style.setProperty('--font-sans', '"Bitter", sans-serif');
-    root.style.setProperty('--font-button', '"Oswald", sans-serif');
-    
-    // Load Google Fonts
+
     const loadFont = (fontName: string) => {
       if (!document.querySelector(`link[href*="${encodeURIComponent(fontName)}"]`)) {
         const link = document.createElement('link');
@@ -86,10 +74,29 @@ function HomeContent() {
         document.head.appendChild(link);
       }
     };
-    
-    loadFont('Anton');
-    loadFont('Bitter');
-    loadFont('Oswald');
+
+    const colors = theme.colors || {};
+    Object.entries(colors).forEach(([key, value]) => {
+      root.style.setProperty(`--color-${key}`, String(value));
+    });
+
+    const fonts = theme.fonts || {};
+    if (fonts.display) {
+      root.style.setProperty('--font-display', fonts.display);
+      loadFont(fonts.display);
+    }
+    if (fonts.sans) {
+      root.style.setProperty('--font-sans', fonts.sans);
+      loadFont(fonts.sans);
+    }
+    if (fonts.button) {
+      root.style.setProperty('--font-button', fonts.button);
+      loadFont(fonts.button);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
 
     // Set random background image for booking section
     const backgroundImages = [

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -1,0 +1,49 @@
+# Admin Dashboard Manual
+
+This guide explains the tabs found in the admin section of your website. Each tab helps you manage different parts of the site. The descriptions below avoid technical jargon so that anyone can follow them easily.
+
+## Bookings
+- **See all requests** – View a list of event booking requests from visitors.
+- **Filter by status** – Choose between All Bookings, Pending Review, Approved, Rejected, or Alternative Suggested.
+- **Quick actions** – Approve or reject a request right from the list.
+- **Detailed review** – Open a request in a new window for a full overview and to confirm or suggest new times.
+- **Stats at a glance** – Dashboard cards show totals and breakdowns of pending, approved, and rejected bookings.
+
+## Site Copy
+- **Manage text on the site** – Edit the wording used in sections such as hero, about, footer, and others.
+- **Create new sections** – Add additional copy sections if needed.
+- **Edit or update content** – Adjust existing text through a pop‑up editor.
+- **Toast messages** – Small notifications confirm when content is saved or if something goes wrong.
+
+## Menu
+- **Add menu items** – Enter new dishes with name, description, price, and tags (e.g. vegetarian).
+- **Organize by group** – Categorize items (Appetizers, Mains, Desserts, etc.).
+- **Control visibility** – Switch items on or off to show or hide them on the public menu.
+- **Edit or delete items** – Adjust details or remove dishes using dialog windows.
+- **Drag‑and‑drop order** – Items are automatically sorted by group and name to keep things tidy.
+
+## Testimonials
+- **Collect client reviews** – Add or edit quotes and star ratings from customers.
+- **Approval switch** – Decide which testimonials appear on the site by toggling them on or off.
+- **Drag to reorder** – Arrange reviews by dragging the handle next to each one.
+- **Simple editing** – Use pop‑ups to modify content or delete unwanted testimonials.
+
+## Gallery
+- **Upload event photos** – Add images along with titles and descriptions.
+- **Mark as featured** – Highlight special images for event showcases.
+- **Toggle visibility** – Show or hide individual photos without deleting them.
+- **Drag‑and‑drop layout** – Reorder images in the grid by dragging them.
+- **Edit or delete** – Change image details or remove them entirely with confirmation prompts.
+
+## Media
+- **Basic file library** – View uploaded media items such as images.
+- **Sample data option** – Quickly add example files for testing if the library is empty.
+- **Refresh list** – Reload the data to see new items or updates.
+
+## Design Tools
+- **Color Manager** – Pick and fine‑tune the color palette used across the site.
+- **Font Switcher** – Experiment with different fonts for headings, text, and buttons.
+- **Preview changes live** – Colors and fonts update instantly in your browser so you can see the results.
+- **Save Theme** – When you’re happy with the design, click **Save Theme** to store your choices for everyone to see.
+
+Use this manual as a quick reference while working in the admin dashboard. Each tab focuses on a specific area of site management, making it easy to keep your content, menu, and overall design up to date.

--- a/lib/useApi.ts
+++ b/lib/useApi.ts
@@ -7,7 +7,7 @@ export default function useApi<T>(endpoint: string) {
   useEffect(() => {
     let isMounted = true
     console.log(`🌐 [useApi] Fetching: /api/${endpoint}`)
-    fetch(`/api/${endpoint}`)
+    fetch(`/api/${endpoint}`, { cache: 'no-store' })
       .then(res => {
         console.log(`📡 [useApi] Response status: ${res.status} for /api/${endpoint}`)
         if (!res.ok) {

--- a/lib/useTheme.ts
+++ b/lib/useTheme.ts
@@ -1,0 +1,30 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+type ThemeDoc = {
+  colors?: Record<string, string>
+  fonts?: Record<string, string>
+}
+
+export default function useTheme() {
+  const [theme, setTheme] = useState<ThemeDoc | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    fetch('/api/public/content?collection=theme', { cache: 'no-store' })
+      .then(res => res.json())
+      .then(json => {
+        const item = Array.isArray(json.data) ? json.data[0] : null
+        if (isMounted) setTheme(item || null)
+      })
+      .catch(err => {
+        console.error('Failed to fetch theme:', err)
+        if (isMounted) setTheme(null)
+      })
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return theme
+}


### PR DESCRIPTION
## Summary
- set `revalidate = 0` and add cache headers for public content API
- use no-store cache header in public events API
- fetch API data without caching
- add hook to retrieve theme values from Firestore
- apply theme colors/fonts dynamically on the homepage

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6882478a3c608323b373ba1eff4fba73