### PR TITLE
Fix public API usage for site copy and menu

### DIFF
--- a/app/api/public/content/route.ts
+++ b/app/api/public/content/route.ts
@@ -9,12 +9,8 @@ export async function GET(request: NextRequest) {
   try {
     console.log('📖 Public Content API: Fetching public content...');
     
-    const url = new URL(request.url);
-    const collection = url.searchParams.get('collection');
-    
-    if (!collection) {
-      return NextResponse.json({ error: 'Collection parameter is required' }, { status: 400 });
-    }
+  const url = new URL(request.url);
+  const collection = url.searchParams.get('collection') || 'content';
 
     // Validate allowed collections for public access
     const allowedCollections = [

--- a/app/api/public/menu/route.ts
+++ b/app/api/public/menu/route.ts
@@ -1,0 +1,22 @@
+import { db } from '@/lib/firebase-admin'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  const snap = await db.collection('menuItems')
+    .where('visible', '==', true)
+    .get()
+  const data = snap.docs.map((d: any) => ({ id: d.id, ...d.data() }))
+  // Sort by group, then by name
+  const sortedData = data.sort((a: any, b: any) => {
+    if (a.group !== b.group) {
+      return a.group.localeCompare(b.group)
+    }
+    return a.name.localeCompare(b.name)
+  })
+  return NextResponse.json(sortedData, {
+    headers: { 'Cache-Control': 'no-store, must-revalidate' }
+  })
+} 

--- a/app/api/public/testimonials/route.ts
+++ b/app/api/public/testimonials/route.ts
@@ -1,0 +1,17 @@
+import { db } from '@/lib/firebase-admin'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  const snap = await db.collection('testimonials')
+    .where('approved', '==', true)
+    .get()
+  const data = snap.docs.map((d: any) => ({ id: d.id, ...d.data() }))
+  // Sort by order in JavaScript since compound queries require indexes
+  const sortedData = data.sort((a: any, b: any) => (a.order || 0) - (b.order || 0))
+  return NextResponse.json(sortedData, {
+    headers: { 'Cache-Control': 'no-store, must-revalidate' }
+  })
+} 

--- a/app/components/EventHighlights.tsx
+++ b/app/components/EventHighlights.tsx
@@ -61,7 +61,7 @@ export default function EventHighlights() {
 
   return (
     <div className="w-full min-h-[800px] flex items-center justify-center relative overflow-hidden -translate-y-[100px]">
-      <div className="relative z-10 w-full max-w-7xl mx-auto px-16 flex items-center justify-between h-full translate-y-28">
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-4 sm:px-16 flex items-center justify-between h-full translate-y-28">
         <button
           onClick={prev}
           aria-label="Previous"
@@ -70,7 +70,7 @@ export default function EventHighlights() {
           <ChevronLeft className="w-4 h-4 text-white" />
         </button>
 
-        <div className="flex-1 mx-12 flex items-center justify-center gap-16">
+        <div className="flex-1 mx-0 sm:mx-12 flex items-center justify-center gap-8 sm:gap-16">
           <div className="flex-1 max-w-lg">
             <h2 className="text-3xl font-bold uppercase mb-4 text-accent2">
               {events[index]?.title || 'Loading...'}
@@ -84,7 +84,7 @@ export default function EventHighlights() {
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="-100 -100 200 200"
-    className="w-full max-w-[800px] h-[800px] pointer-events-none"
+    className="w-full max-w-[350px] h-[350px] sm:max-w-[800px] sm:h-[800px] pointer-events-none"
     clipPathUnits="userSpaceOnUse"
   >
               <defs>

--- a/app/components/MobilePlateCarousel.tsx
+++ b/app/components/MobilePlateCarousel.tsx
@@ -17,7 +17,7 @@ export default function MobilePlateCarousel() {
   const [currentIndex, setCurrentIndex] = useState(0)
   const touchStartX = useRef(0)
   const touchEndX = useRef(0)
-  const menuItems = useApi<MenuItem>('menu')
+  const menuItems = useApi<MenuItem>('public/menu')
 
   // ── Use only one plate with no text as the first image ──────────────────
   const firstPlate = '/images/plate-no-text/plate-1_0007_Marzapane-dessert-verde-antico.png'

--- a/app/components/PlateStack.tsx
+++ b/app/components/PlateStack.tsx
@@ -21,7 +21,7 @@ type MenuItem = {
 export default function PlateStack() {
   const stackRef = useRef<HTMLDivElement>(null)
   const [shuffledPlates, setShuffledPlates] = useState<string[]>([])
-  const menuItems = useApi<MenuItem>('menu')
+  const menuItems = useApi<MenuItem>('public/menu')
 
   // ── plates with no text ───────────────────────────────────────────────
   const noTextPathsOriginal = [

--- a/app/components/QuoteChat.tsx
+++ b/app/components/QuoteChat.tsx
@@ -50,13 +50,17 @@ const QuoteChat: React.FC = () => {
 
   useEffect(() => {
     if (inputRef.current && !isLoading && !showBookingForm) {
-      try {
-        inputRef.current.focus({ preventScroll: true });
-      } catch {
-        inputRef.current.focus();        // fallback for browsers that don't support preventScroll
+      const isDesktop =
+        typeof window !== 'undefined' && window.innerWidth >= 1024
+      if (isDesktop) {
+        try {
+          inputRef.current.focus({ preventScroll: true })
+        } catch {
+          inputRef.current.focus() // fallback for browsers that don't support preventScroll
+        }
       }
     }
-  }, [isLoading, showBookingForm]);
+  }, [isLoading, showBookingForm])
 
   /* initial greeting */
   useEffect(() => {

--- a/app/components/TestimonialsSection.tsx
+++ b/app/components/TestimonialsSection.tsx
@@ -22,7 +22,7 @@ export default function TestimonialsSection() {
   const [index, setIndex] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
   const carouselRef = useRef<HTMLDivElement>(null)
-  const testimonials = useApi<Testimonial>('testimonials')
+  const testimonials = useApi<Testimonial>('public/testimonials')
   
   // Debug: Log the raw testimonials data
   useEffect(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ function HomeContent() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const { scrollY } = useScroll();
-  const contentData = useApi<ContentItem>('content');
+  const contentData = useApi<ContentItem>('public/content');
   
   // Helper function to get content by section
   const getContent = (section: string, fallback: string = '') => {

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -1,0 +1,49 @@
+# Admin Dashboard Manual
+
+This guide explains the tabs found in the admin section of your website. Each tab helps you manage different parts of the site. The descriptions below avoid technical jargon so that anyone can follow them easily.
+
+## Bookings
+- **See all requests** – View a list of event booking requests from visitors.
+- **Filter by status** – Choose between All Bookings, Pending Review, Approved, Rejected, or Alternative Suggested.
+- **Quick actions** – Approve or reject a request right from the list.
+- **Detailed review** – Open a request in a new window for a full overview and to confirm or suggest new times.
+- **Stats at a glance** – Dashboard cards show totals and breakdowns of pending, approved, and rejected bookings.
+
+## Site Copy
+- **Manage text on the site** – Edit the wording used in sections such as hero, about, footer, and others.
+- **Create new sections** – Add additional copy sections if needed.
+- **Edit or update content** – Adjust existing text through a pop‑up editor.
+- **Toast messages** – Small notifications confirm when content is saved or if something goes wrong.
+
+## Menu
+- **Add menu items** – Enter new dishes with name, description, price, and tags (e.g. vegetarian).
+- **Organize by group** – Categorize items (Appetizers, Mains, Desserts, etc.).
+- **Control visibility** – Switch items on or off to show or hide them on the public menu.
+- **Edit or delete items** – Adjust details or remove dishes using dialog windows.
+- **Drag‑and‑drop order** – Items are automatically sorted by group and name to keep things tidy.
+
+## Testimonials
+- **Collect client reviews** – Add or edit quotes and star ratings from customers.
+- **Approval switch** – Decide which testimonials appear on the site by toggling them on or off.
+- **Drag to reorder** – Arrange reviews by dragging the handle next to each one.
+- **Simple editing** – Use pop‑ups to modify content or delete unwanted testimonials.
+
+## Gallery
+- **Upload event photos** – Add images along with titles and descriptions.
+- **Mark as featured** – Highlight special images for event showcases.
+- **Toggle visibility** – Show or hide individual photos without deleting them.
+- **Drag‑and‑drop layout** – Reorder images in the grid by dragging them.
+- **Edit or delete** – Change image details or remove them entirely with confirmation prompts.
+
+## Media
+- **Basic file library** – View uploaded media items such as images.
+- **Sample data option** – Quickly add example files for testing if the library is empty.
+- **Refresh list** – Reload the data to see new items or updates.
+
+## Design Tools
+- **Color Manager** – Pick and fine‑tune the color palette used across the site.
+- **Font Switcher** – Experiment with different fonts for headings, text, and buttons.
+- **Preview changes live** – Colors and fonts update instantly in your browser so you can see the results.
+- **Save Theme** – When you’re happy with the design, click **Save Theme** to store your choices for everyone to see.
+
+Use this manual as a quick reference while working in the admin dashboard. Each tab focuses on a specific area of site management, making it easy to keep your content, menu, and overall design up to date.


### PR DESCRIPTION
## Summary
- default `/api/public/content` to return `content` collection when no query parameter is passed
- add `/api/public/menu` and `/api/public/testimonials` endpoints
- use new public API paths in Home page and plate/testimonial components

## Testing
- `pnpm lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688250b309748323a45906936096bff8